### PR TITLE
Feature/create yaml from folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 
 # Test notebooks
 **/tests/notebooks
+.idea/
+*.tif

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ scikit-image>=0.17.2
 shapely==1.7.1
 openslide-python>=1.1.1
 PyYAML>=5.4.1
-ruamel.yaml>=0.17.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-image>=0.17.2
 shapely==1.7.1
 openslide-python>=1.1.1
 PyYAML>=5.4.1
+ruamel.yaml>=0.17.21


### PR DESCRIPTION
Single method to create a yaml with a structure as follows:
```
training:
  - wsi:
      path: 
    wsa:
      path:
validation:
  - wsi:
      path: 
    wsa:
      path:
```
It has a parameter called train_split, which is a percentile that is used in np.choice to probablistically create the train / validation split. This alleviates keeping track of the amount of all WSIs and how many there are per class etc. 