### PR TITLE
use github url as package website

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email="mart.vanrijthoven@gmail.com",
     package_data={"": ["*.yml"]},
     packages=find_packages(exclude=("tests", "notebooks", "docs")),
-    url="http://pypi.python.org/pypi/wholeslidedata/",
+    url="https://github.com/DIAGNijmegen/pathology-whole-slide-data",
     license="LICENSE.txt",
     install_requires=[package.strip() for package in open("./requirements.txt").readlines()],
     long_description="Package for working with whole slide images.",


### PR DESCRIPTION
Before this commit, the URL pointed to the Pypi website. When this link is clicked on the Pypi page for wholeslidedata, it simply reloads the page. The github page of this project could be used as the URL instead.