### PR TITLE
Added scale multiplication to plot_annotations when using base_coordinates

### DIFF
--- a/wholeslidedata/annotation/utils.py
+++ b/wholeslidedata/annotation/utils.py
@@ -140,7 +140,7 @@ def plot_annotations(
         )
 
         if use_base_coordinates:
-            coordinates = annotation.base_coordinates
+            coordinates = annotation.base_coordinates * scale
         else:
             coordinates = annotation.coordinates * scale
 


### PR DESCRIPTION
In the annotation.utils.plot_annotation function, the scale multiplication was not applied when use_base_coordinates was True. I changed this by adding a scale multiplication for this case as well.