### PR TITLE
Add class for indexed masks

### DIFF
--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -98,6 +98,54 @@ class WholeSlideMaskWriter(WholeSlideImageWriterBase):
         self.setSpacing(pixel_size_vec)
         self.writeImageInformation(self._dimensions[0], self._dimensions[1])
 
+class WholeSlideIndexedMaskWriter(WholeSlideImageWriterBase):
+    def __init__(self, suffix=".tif"):
+        super().__init__()
+        self._suffix = suffix
+
+    def _set_monochrome_channels(self, dimensions):
+        if len(dimensions) > 2:
+            return len(dimensions)
+        elif len(dimensions) == 2:
+            return 1
+        else:
+            raise Exception("Invalid dimensions")
+
+    def write(self, path, spacing, dimensions, tile_shape):
+        self._path = str(path).replace(Path(path).suffix, self._suffix)
+        self._spacing = spacing
+        self._dimensions = dimensions
+        self._tile_shape = tile_shape
+        self._channels = self._set_monochrome_channels(dimensions)
+
+        print(f"Creating: {self._path}....")
+        print(f"Spacing: {self._spacing}")
+        print(f"Dimensions: {self._dimensions}")
+        print(f"Tile_shape: {self._tile_shape}")
+        print(f"Indexed channels: {self._channels}")
+
+        self.openFile(self._path)
+        self.setTileSize(self._tile_shape[0])
+
+        try:
+            self.setCompression(mir.Compression_LZW)
+            self.setDataType(mir.DataType_UChar)
+            self.setInterpolation(mir.Interpolation_NearestNeighbor)
+            self.setColorType(mir.ColorType_Indexed)
+            self.setNumberOfIndexedColors(self._channels)
+        except:
+            self.setCompression(mir.LZW)
+            self.setDataType(mir.UChar)
+            self.setInterpolation(mir.NearestNeighbor)
+            self.setColorType(mir.Indexed)
+            self.setNumberOfIndexedColors(self._channels)
+
+        # set writing spacing
+        pixel_size_vec = mir.vector_double()
+        pixel_size_vec.push_back(self._spacing)
+        pixel_size_vec.push_back(self._spacing)
+        self.setSpacing(pixel_size_vec)
+        self.writeImageInformation(self._dimensions[0], self._dimensions[1])
 
 class WholeSlideImageWriter(WholeSlideImageWriterBase):
     def __init__(self, suffix=".tif"):

--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -103,7 +103,7 @@ class WholeSlideIndexedMaskWriter(WholeSlideImageWriterBase):
         super().__init__()
         self._suffix = suffix
 
-    def _set_monochrome_channels(self, dimensions):
+    def _set_indexed_channels(self, dimensions):
         if len(dimensions) > 2:
             return len(dimensions)
         elif len(dimensions) == 2:

--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -116,7 +116,7 @@ class WholeSlideIndexedMaskWriter(WholeSlideImageWriterBase):
         self._spacing = spacing
         self._dimensions = dimensions
         self._tile_shape = tile_shape
-        self._channels = self._set_monochrome_channels(dimensions)
+        self._channels = self._set_indexed_channels(dimensions)
 
         print(f"Creating: {self._path}....")
         print(f"Spacing: {self._spacing}")


### PR DESCRIPTION
**Added:**
Added new class WholeSlideIndexedMaskWriter which extends the existing WholeSlideImageWriterBase class. This new class writes indexed binary masks for whole slide images.

To support indexed masks, the _set_indexed_channels() method has been added to determine the number of channels based on the dimensions of the binary mask. If the dimensions are 2D, then a single channel is used, while for 3D dimensions, the number of channels equals the number of dimensions.

The write() method is modified to set the color type as indexed and the number of indexed colors to the channels determined earlier by the _set_monochrome_channels() method. The method also sets other necessary parameters for writing the indexed mask such as the tile size, compression, and interpolation.

A print statement is added to display the number of indexed channels in the mask along with other details.


**Note:**
To make the functionality more clear between the monochrome and indexed writer this could be a rename, I would even drop the name WholeSlide maybe. :

WholeSlideMonochromeMaskWriter: This name emphasizes that the class is responsible for writing monochrome (single-channel) masks for whole slide images.

WholeSlideIndexedColorMaskWriter: This name emphasizes that the class is responsible for writing indexed-color masks (which can have multiple channels) for whole slide images.