### PR TITLE
fix for cases in which Classification key is not present #51

### DIFF
--- a/wholeslidedata/interoperability/qupath/parser.py
+++ b/wholeslidedata/interoperability/qupath/parser.py
@@ -10,8 +10,9 @@ class QuPathAnnotationParser(AnnotationParser):
     def get_available_labels(opened_annotation: dict):
         labels = set(
             [
-                annotation["properties"]["classification"]["name"]
-                for annotation in opened_annotation
+        annotation.get("properties", {}).get("classification", {}).get("name")
+        for annotation in opened_annotation
+        if annotation.get("properties", {}).get("classification") and annotation.get("properties", {}).get("classification", {}).get("name")
             ]
         )
         labels = list(zip(labels, list(range(len(labels)))))


### PR DESCRIPTION
Fixes #51 

The current implementation did not handle cases in which the "Classification" key was not present in the GeoJSON file.
This PR handle this case, which can happen when we wan to classify cells inside of a ROI. The ROI will not have a Classification Key.
The result of this operation only include annotation that have a "Classification" key and ignore those who have not.

Matteo 