### PR TITLE
Update `DetectionPatchLabelSampler`

### DIFF
--- a/wholeslidedata/samplers/patchlabelsampler.py
+++ b/wholeslidedata/samplers/patchlabelsampler.py
@@ -232,10 +232,10 @@ class DetectionPatchLabelSampler(PatchLabelSampler):
         if self._point_box_sizes is not None:
             size = np.array(self._point_box_sizes[annotation.label.name])
 
-        x1 = int(max(0, coordinates[0] - (size // 2)))
-        y1 = int(max(0, coordinates[1] - (size // 2)))
-        x2 = int(min(width-1, coordinates[0] + (size // 2)))
-        y2 = int(min(height-1, coordinates[1] + (size // 2)))
+        x1 = int(max(0, coordinates[0][0] - (size // 2)))
+        y1 = int(max(0, coordinates[0][1] - (size // 2)))
+        x2 = int(min(width - 1, coordinates[0][0] + (size // 2)))
+        y2 = int(min(height - 1, coordinates[0][1] + (size // 2)))
         if x2 <= x1:
             return None
         if y2 <= y1:


### PR DESCRIPTION
The `DetectionPatchLabelSampler` class still indexes the coordinates of PointAnnotations as if they had shape (2,), while they now have shape (1,2). Therefore we have to switch to `x = coordinates[0][0]` from `x = coordinates[0]`.