### PR TITLE
Update imagewriter.py with tile and coordinate checks and corrections

### DIFF
--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -87,14 +87,6 @@ class WholeSlideImageWriterBase(Writer, MultiResolutionImageWriter):
             if x >= self._dimensions[0] or y >= self._dimensions[1]:
                 print(f"Tile's upper left coordinates {coordinates} are completely outside the dimensions {self._dimensions}... Skipping tile...")
                 return None
-
-            x_end = x + self._tile_shape[0]
-            y_end = y + self._tile_shape[1]
-            if x_end > self._dimensions[0] or y_end > self._dimensions[1]:
-                print(f"Tile's lower right coordinates {x_end, y_end} are exeeding the dimensions {self._dimensions}... Cropping tile to fit inside the dimensions...")
-                tile_max_x = self._dimensions[0] - x
-                tile_max_y = self._dimensions[1] - y
-                tile = tile[:tile_max_x, :tile_max_y]
         return tile
 
     def write_tile(self, tile, coordinates=None, mask=None):

--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -75,25 +75,26 @@ class WholeSlideImageWriterBase(Writer, MultiResolutionImageWriter):
                 f"Invalid tile shape initialized: {self._tile_shape}, tile shape should contain at 2 or 3 dimensions"
             )
 
-        # Check if coordinates are aligned with the predefined tile grid
-        if coordinates[0] % self._tile_shape[0] != 0 or coordinates[1] % self._tile_shape[1] != 0:
-            raise CoordinateError(
-                f"Coordinates {coordinates} are not multiples of the tile size {self._tile_shape[:2]}"
-            )
+        if coordinates: 
+            x, y = coordinates
+            # Check if coordinates are aligned with the predefined tile grid
+            if x % self._tile_shape[0] != 0 or y % self._tile_shape[1] != 0:
+                raise CoordinateError(
+                    f"Coordinates {coordinates} are not multiples of the tile size {self._tile_shape[:2]}"
+                )
+    
+            # Check if coordinates are within the dimensions
+            if x >= self._dimensions[0] or y >= self._dimensions[1]:
+                print(f"Tile's upper left coordinates {coordinates} are completely outside the dimensions {self._dimensions}... Skipping tile...")
+                return None
 
-        # Check if coordinates are within the dimensions
-        x, y = coordinates
-        if x >= self._dimensions[0] or y >= self._dimensions[1]:
-            print(f"Tile coordinates {coordinates} are completely outside the dimensions {self._dimensions}... Skipping tile...")
-            return None
-
-        x_end = x + self._tile_shape[0]
-        y_end = y + self._tile_shape[1]
-        if x_end > self._dimensions[0] or y_end > self._dimensions[1]:
-            print(f"Tile outer coordinates {x_end, y_end} are exeeding the dimensions {self._dimensions}... Cropping tile to fit inside the dimensions...")
-            tile_max_x = self._dimensions[0] - x
-            tile_max_y = self._dimensions[1] - y
-            tile = tile[:tile_max_x, :tile_max_y]
+            x_end = x + self._tile_shape[0]
+            y_end = y + self._tile_shape[1]
+            if x_end > self._dimensions[0] or y_end > self._dimensions[1]:
+                print(f"Tile's lower right coordinates {x_end, y_end} are exeeding the dimensions {self._dimensions}... Cropping tile to fit inside the dimensions...")
+                tile_max_x = self._dimensions[0] - x
+                tile_max_y = self._dimensions[1] - y
+                tile = tile[:tile_max_x, :tile_max_y]
         return tile
 
     def write_tile(self, tile, coordinates=None, mask=None):

--- a/wholeslidedata/interoperability/asap/imagewriter.py
+++ b/wholeslidedata/interoperability/asap/imagewriter.py
@@ -59,13 +59,10 @@ class WholeSlideImageWriterBase(Writer, MultiResolutionImageWriter):
         MultiResolutionImageWriter.__init__(self)
 
     def _tile_and_coordinate_checks_and_corrections(self, tile, coordinates):
-        # Check if tile shape == self._tile_shape
         if tile.shape != self._tile_shape:
             raise TileShapeError(
                 f"Tile shape {tile.shape} does not match expected shape {self._tile_shape}"
             )
-
-        # Check if tile shape is 2 or 3
         if len(tile.shape) != 2 and len(tile.shape) != 3:
             raise TileShapeError(
                 f"Invalid tile shape provided: {tile.shape}, tile shape should contain at 2 or 3 dimensions"
@@ -74,16 +71,12 @@ class WholeSlideImageWriterBase(Writer, MultiResolutionImageWriter):
             raise TileShapeError(
                 f"Invalid tile shape initialized: {self._tile_shape}, tile shape should contain at 2 or 3 dimensions"
             )
-
         if coordinates: 
             x, y = coordinates
-            # Check if coordinates are aligned with the predefined tile grid
             if x % self._tile_shape[0] != 0 or y % self._tile_shape[1] != 0:
                 raise CoordinateError(
                     f"Coordinates {coordinates} are not multiples of the tile size {self._tile_shape[:2]}"
                 )
-    
-            # Check if coordinates are within the dimensions
             if x >= self._dimensions[0] or y >= self._dimensions[1]:
                 print(f"Tile's upper left coordinates {coordinates} are completely outside the dimensions {self._dimensions}... Skipping tile...")
                 return None


### PR DESCRIPTION
As discussed with multiple people from our group the wrapped ASAP image writer sometimes exhibits unexaplainable behaviour that is very hard to debug. In this PR I intend to prevent some of the obvious mistakes to pass without errors. If possible I correct the tile. By doing this the writer becomes more robust and guides the user on what to fix, instead of ambiguously trying to keep the loop going without throwing warnings or errors.

I think the _crop_tile function and the _get_row_col function already partly do some of these checks, but neither throw errors or warnings, causign outputs that are incorrect and leaving users unaware of what went wrong. I left them in right now though, the new function takes care of possible errors. 

I havent tested this yet but I would like to share this already so we can finalize it together.
@martvanrijthoven @daangeijs @carlijnlems @nfsuysal @leandervaneekelen @rolandnemeth000   