### PR TITLE
Patch commander fix

### DIFF
--- a/wholeslidedata/buffer/patchcommander.py
+++ b/wholeslidedata/buffer/patchcommander.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from wholeslidedata.image.wholeslideimage import WholeSlideImage
-
+from wholeslidedata.samplers.utils import crop_data
 
 @dataclass
 class PatchConfiguration:
@@ -15,7 +15,7 @@ class PatchConfiguration:
     overlap: tuple = (0, 0)
     offset: tuple = (0, 0)
     center: bool = False
-
+    write_shape: tuple = None # This can be used when you crop off (overlapping) borders of the patches, only patches with mask in the inner part will be sampled
 
 class PatchCommander(Commander):
     def __init__(
@@ -89,8 +89,20 @@ class SlidingPatchCommander(PatchCommander):
         
         if self._mask_path is not None:
             self._mask = WholeSlideImage(self._mask_path, backend=self._backend, auto_resample=True)
-        for row in range(self._patch_configuration.offset[1], self._y_dims, step_row):
-            for col in range(self._patch_configuration.offset[0], self._x_dims, step_col):
+
+        x_min = self._patch_configuration.offset[0]
+        y_min = self._patch_configuration.offset[1]
+        x_max = self._x_dims + self._patch_configuration.offset[0] + self._patch_configuration.patch_shape[0] // 2 if self._patch_configuration.center else self._x_dims + self._patch_configuration.offset[0]
+        y_max = self._y_dims + self._patch_configuration.offset[1] + self._patch_configuration.patch_shape[1] // 2 if self._patch_configuration.center else self._y_dims + self._patch_configuration.offset[1]
+
+        # Add one extra patch on all sides to avoid missing out on patches in more complex patch configurations (e.g. with overlap and offset)
+        x_min_extra = x_min - step_row
+        y_min_extra = y_min - step_col
+        x_max_extra = x_max + step_row
+        y_max_extra = y_max + step_col
+
+        for row in range(y_min_extra, y_max_extra, step_row):
+            for col in range(x_min_extra, x_max_extra, step_col):
                 if self._mask is not None:
                     mask = self._mask.get_patch(
                         x=col,
@@ -102,6 +114,10 @@ class SlidingPatchCommander(PatchCommander):
                         relative=self._level_0_spacing,
                     )
 
+                    if self._patch_configuration.write_shape is not None:
+                        mask = crop_data(mask, self._patch_configuration.write_shape)
+                        if np.all(mask == 0):
+                            continue
                     if np.all(mask == 0):
                         continue
 


### PR DESCRIPTION
Fix for patch commander skipping patches that should be sampled on the borders. Also adds new optional functionality to not sample patches that do not have mask in the write-shape. This write shape is the shape to which the user will center crop the patches provided by the iterator for sliding window configs with overlap, where you crop off the overlapping borders