### PR TITLE
Fix for patch commander

### DIFF
--- a/wholeslidedata/buffer/patchcommander.py
+++ b/wholeslidedata/buffer/patchcommander.py
@@ -100,13 +100,13 @@ class SlidingPatchCommander(PatchCommander):
 
         # Add one extra patch on all sides to avoid missing out on patches in more complex patch configurations (e.g. with overlap and offset)
         if any(self._patch_configuration.offset) or any(self._patch_configuration.overlap):
-            x_min_extra = x_min - step_row
-            y_min_extra = y_min - step_col
-            x_max_extra = x_max + step_row
-            y_max_extra = y_max + step_col
+            x_min = x_min - step_row
+            y_min = y_min - step_col
+            x_max = x_max + step_row
+            y_max = y_max + step_col
 
-        for row in range(y_min_extra, y_max_extra, step_row):
-            for col in range(x_min_extra, x_max_extra, step_col):
+        for row in range(y_min, y_max, step_row):
+            for col in range(x_min, x_max, step_col):
                 if wsm is not None:
                     mask = wsm.get_patch(
                         x=col,

--- a/wholeslidedata/buffer/patchcommander.py
+++ b/wholeslidedata/buffer/patchcommander.py
@@ -91,7 +91,7 @@ class SlidingPatchCommander(PatchCommander):
         
         wsm = None
         if self._mask_path is not None:
-            self.wsm = WholeSlideImage(self._mask_path, backend=self._backend, auto_resample=True)
+            wsm = WholeSlideImage(self._mask_path, backend=self._backend, auto_resample=True)
 
         x_min = self._patch_configuration.offset[0]
         y_min = self._patch_configuration.offset[1]
@@ -106,8 +106,8 @@ class SlidingPatchCommander(PatchCommander):
 
         for row in range(y_min_extra, y_max_extra, step_row):
             for col in range(x_min_extra, x_max_extra, step_col):
-                if self.wsm is not None:
-                    mask = self.wsm.get_patch(
+                if wsm is not None:
+                    mask = wsm.get_patch(
                         x=col,
                         y=row,
                         width=self._patch_configuration.patch_shape[1],

--- a/wholeslidedata/buffer/patchcommander.py
+++ b/wholeslidedata/buffer/patchcommander.py
@@ -99,10 +99,11 @@ class SlidingPatchCommander(PatchCommander):
         y_max = self._y_dims + self._patch_configuration.offset[1] + self._patch_configuration.patch_shape[1] // 2 if self._patch_configuration.center else self._y_dims + self._patch_configuration.offset[1]
 
         # Add one extra patch on all sides to avoid missing out on patches in more complex patch configurations (e.g. with overlap and offset)
-        x_min_extra = x_min - step_row
-        y_min_extra = y_min - step_col
-        x_max_extra = x_max + step_row
-        y_max_extra = y_max + step_col
+        if any(self._patch_configuration.offset) or any(self._patch_configuration.overlap):
+            x_min_extra = x_min - step_row
+            y_min_extra = y_min - step_col
+            x_max_extra = x_max + step_row
+            y_max_extra = y_max + step_col
 
         for row in range(y_min_extra, y_max_extra, step_row):
             for col in range(x_min_extra, x_max_extra, step_col):


### PR DESCRIPTION
Fix for patch commander skipping patches that should be sampled on the borders. Also adds new optional functionality to not sample patches that do not have mask in the write-shape. This write shape is the shape to which the user will center crop the patches provided by the iterator for sliding window configs with overlap, where you crop off the overlapping borders